### PR TITLE
Trim whitespace string before performing minLength validation.

### DIFF
--- a/packages/composable-validation/src/validators/text.test.ts
+++ b/packages/composable-validation/src/validators/text.test.ts
@@ -42,6 +42,15 @@ describe('textValidators', () => {
       expect(minLength(3)('123').length).toBe(0)
       expect(minLength(3)('1234').length).toBe(0)
     })
+
+    it('returns error if string right length but all whitespace', () => {
+        expect(minLength(3)('   ').length).toBeGreaterThan(0)
+    })
+
+    it('returns error if string right length but with initial or trailing whitespace', () => {
+        expect(minLength(3)(' 12').length).toBeGreaterThan(0)
+        expect(minLength(3)('12 ').length).toBeGreaterThan(0)
+    })
   })
 
   describe('validEmail', () => {

--- a/packages/composable-validation/src/validators/text.ts
+++ b/packages/composable-validation/src/validators/text.ts
@@ -4,7 +4,7 @@ export const maxLength = (max: number): ValueValidator<string> =>
   (value: string) => value.length > max ? [`Must be less than ${max} characters`] : valid
 
 export const minLength = (min: number): ValueValidator<string> =>
-  (value: string) => value.length < min ? [`Must be at least ${min} characters`] : valid
+  (value: string) => value.trim().length < min ? [`Must be at least ${min} characters`] : valid
 
 export const validEmail: ValueValidator<string> = (email: string) => {
   const parts = email.split('@')


### PR DESCRIPTION
Hi Dean,

We're using the minLength validator for front end validation, but it doesn't quite match our backend validation where e.g. the string "   " is rejected, even though it is the right length.

This may or may not be the right approach in general.

DG